### PR TITLE
NEW: Make NXConverter a context manager which raises human-friendly errors

### DIFF
--- a/creator/nx_creator_ptycho.py
+++ b/creator/nx_creator_ptycho.py
@@ -148,8 +148,8 @@ class NXCreator:
 
 
     def create_beam_group(self,
+                          energy: float,
                           entry_number: int=1,
-                          energy: float = None,
                           wavelength: float = None,
                           extent: float = None,
                           polarization: float = None,
@@ -166,10 +166,10 @@ class NXCreator:
             self._create_dataset(self.beam_group, "polarization", polarization, unit='a.u')
 
     def create_detector_group(self,
-                              data: np.ndarray = None,
-                              distance: float = None,
-                              x_pixel_size: float = None,
-                              y_pixel_size: float = None,
+                              data: np.ndarray,
+                              distance: float,
+                              x_pixel_size: float,
+                              y_pixel_size: float,
                               *args,
                               **kwargs):
 

--- a/creator/nx_creator_ptycho.py
+++ b/creator/nx_creator_ptycho.py
@@ -43,7 +43,7 @@ class NXCreator:
         )
 
     """
-    
+
     def __init__(self, output_filename):
         self._output_filename = output_filename
         self.entry_group_name = None
@@ -60,12 +60,15 @@ class NXCreator:
         print(group.name)
         return group
 
-    def init_file(self):
+    def __enter__(self):
         """Write the complete NeXus file."""
         #TODO check how this can be shared with other converters or moved to different module
         with h5py.File(self._output_filename, "w") as file:
             self.write_file_header(file)
+        return self
 
+    def __exit__(self, type, value, traceback):
+        pass
 
     def write_file_header(self, output_file):
         """optional header metadata"""

--- a/creator/nx_creator_ptycho.py
+++ b/creator/nx_creator_ptycho.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 NX_APP_DEF_NAME = "NXptycho"
 NX_EXTENSION = ".nxs"
 
+
+class MissingRequiredDataError(TypeError):
+    pass
+
+
 class NXCreator:
     """
     Manage NeXus file creation for Ptychography data.
@@ -68,7 +73,10 @@ class NXCreator:
         return self
 
     def __exit__(self, type, value, traceback):
-        pass
+        if type is TypeError:
+            raise MissingRequiredDataError(
+                'Check the above TypeError; data required for the NXPtycho'
+                ' format was possibly omitted.') from value
 
     def write_file_header(self, output_file):
         """optional header metadata"""

--- a/test_context.py
+++ b/test_context.py
@@ -1,6 +1,0 @@
-from creator.nx_creator_ptycho import NXCreator
-import numpy as np
-
-with NXCreator('test.nx') as creator:
-    creator.create_entry_group()
-    creator.create_beam_group()

--- a/test_context.py
+++ b/test_context.py
@@ -1,0 +1,6 @@
+from creator.nx_creator_ptycho import NXCreator
+import numpy as np
+
+with NXCreator('test.nx') as creator:
+    creator.create_entry_group()
+    creator.create_beam_group()

--- a/toNXconverter.py
+++ b/toNXconverter.py
@@ -65,19 +65,22 @@ def main():
     print('Total number of entries in single file is:', number_of_entries)
     #TODO remove after testing
     number_of_entries = 3
-    creator = NXCreator(output_filename)
-    creator.init_file()
-    for n in range(1, number_of_entries+1):
-        data_dict = loader.data_dict(n)
-    # write the data to a NeXus file
-        creator.create_entry_group(entry_number=n, experiment_description="Ptycho experiment",
-                                           title="Ptychography")
-        creator.create_instrument_group("Ptychography Beamline")
-        creator.create_beam_group(energy=data_dict.get("energy"))
-        creator.create_detector_group(distance=data_dict.get("distance"),
-                                      x_pixel_size=data_dict.get("x_pixel_size"),
-                                      y_pixel_size=data_dict.get("y_pixel_size")
-                                      )
+    with NXCreator(output_filename) as creator:
+        for n in range(1, number_of_entries+1):
+            data_dict = loader.data_dict(n)
+        # write the data to a NeXus file
+            creator.create_entry_group(
+                entry_number=n,
+                experiment_description="Ptycho experiment",
+                title="Ptychography"
+            )
+            creator.create_instrument_group("Ptychography Beamline")
+            creator.create_beam_group(energy=data_dict.get("energy"))
+            creator.create_detector_group(
+                distance=data_dict.get("distance"),
+                x_pixel_size=data_dict.get("x_pixel_size"),
+                y_pixel_size=data_dict.get("y_pixel_size")
+            )
 
 
     logger.info("Wrote HDF5 file: %s", output_filename)


### PR DESCRIPTION
The purpose of this PR is to refactor the NXConverter class so that required data is handled differently. Previously, many parameters had a default value of `None` even if they are required according to the NXcxi_ptycho format requires it to be specified. Now, required data is required by the functions which write it to the file and if the NXConverter is used as a context manager, then the TypeErrors which are raised by missing arguments are chained with a message which tells the user that they may be omitting required arguments.

An alternate approach could be to use function decorators instead of a context manager to annotate missing arguments, but this approach was suggested in the informal meeting.

- [x] Convert NXConverter to a context manager
- [x] Catch and reraise attribute error if required parameters are missing


Demo how errors are handled with the following code bit:
```python
from creator.nx_creator_ptycho import NXCreator

with NXCreator('test.nx') as creator:
    creator.create_entry_group()
    creator.create_beam_group()
```